### PR TITLE
Bugfix #12

### DIFF
--- a/c++/src/entity.cpp
+++ b/c++/src/entity.cpp
@@ -5,9 +5,8 @@
 Entity::Entity(uint16_t id, uint16_t type, Rect boundingRect)
     : id(id), type(type){
     this->setBoundingRect(boundingRect);
-    this->predictPossibleLocations();
     this->trajectory = std::make_shared<LinkedList<TrajectoryNode>>(TrajectoryNode(boundingRect, Velocity2D(0, 0)));
-    // this->calcContour(frameInside);
+    this->predictPossibleLocations();
 }
 
 Entity::Entity(const Entity& e) 

--- a/c++/src/entityUtil.cpp
+++ b/c++/src/entityUtil.cpp
@@ -27,8 +27,8 @@ uint Entity::squareDistanceTo(const Rect& r){
 }
 
 void Entity::predictPossibleLocations(){
+    this->calcAndSetVelocity();
     Point tl = this->getBoundingRect().tl();
-
     const int vX = this->velocity.x*predictions::_velocityCoefficient;
     const int vY = this->velocity.y*predictions::_velocityCoefficient;
     const int w = this->getBoundingRect().width*predictions::_sizeCoefficient*signum(vX);

--- a/c++/src/tracker.cpp
+++ b/c++/src/tracker.cpp
@@ -60,7 +60,6 @@ void Tracker::matchEntity(vector<Entity>& currentEntities, Recognition& currentR
     for (uint16_t j = 0, size = currentEntities.size(); j < size; j++){
         Entity& currentEntity = currentEntities[j];
         uint distanceSquared = UINT32_MAX;
-		currentEntity.calcAndSetVelocity();
 		currentEntity.predictPossibleLocations();
         currentEntity.getPossibleLocation().draw(this->frame, CV_RGB(255, 255, 255));
         uint16_t matchingEntityIndex = UINT16_MAX;


### PR DESCRIPTION
**Bugfix #12**

Found the bug, it was on the entity file 
At first I thought it was a major bug and a big flaw with the logic of the matchEntity function, but then, I realized that maybe another function is using it.
as it came out, a function on the entity creation called that function, before it initialized the trajectory so a segfualt appeared,
luckily it was an easy fix!  